### PR TITLE
Patching a bug introduced in 0996a1b

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Flannel Charm Layer
 
-A minimal layer intended to be "mixed in" with the [Docker Layer](http://github.com/juju-solutions/layer-docker)
+A minimal layer intended to be "mixed in" with the 
+[Docker Layer](http://github.com/juju-solutions/layer-docker)
 to provide Flannel based Overlay Networking to Docker Container infrastructure
 
 This will probably go away into a more generic libnetwork abstraction when
 docker 1.9 launches.
+
+## Configuration
+
+**iface** The interface to configure the flannel SDN binding. If this value is
+empty string or undefined the code will attempt to find the default network 
+adapter similar to the following command:  
+```bash 
+route | grep default | head -n 1 | awk {'print $8'}
+```

--- a/config.yaml
+++ b/config.yaml
@@ -23,3 +23,18 @@ options:
     description: |
       The image to pull for running 'flannel'. Recommended to
       mirror the default on a private registry if connectivity is a concern
+  http_proxy:
+     type: string
+     default:
+     description: |
+        URL to use for HTTP_PROXY to be used by Docker. Only useful in closed
+        environments where a proxy is the only option for routing to the
+        registry to pull images
+  https_proxy:
+    type: string
+    default:
+    description: |
+        URL to use for HTTPS_PROXY to be used by Docker. Only useful in closed
+        environments where a proxy is the only option for routing to the
+        registry to pull images
+

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,11 @@
 options:
   iface:
     type: string
-    default: eth0
+    default: ""
     description: |
-      Interface to bind flannel overlay networking to. Defaults to eth0.
+      The interface to bind flannel overlay networking. The default value is
+      the result of running the following command: 
+      `route | grep default | head -n 1 | awk {'print $8'}`.
   cidr:
     type: string
     default: 10.1.0.0/16

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -61,7 +61,7 @@ def deploy_docker_bootstrap_daemon():
     # future modification. This doesn't add much overhead.
     if codename == 'trusty':
         render('bootstrap-docker.upstart', '/etc/init/bootstrap-docker.conf',
-               {}, owner='root', group='root')
+               config(), owner='root', group='root')
     else:
         # Render the service definition
         render('bootstrap-docker.service',
@@ -174,6 +174,40 @@ def reconfigure_docker_for_sdn():
 
     set_state('docker.restart')
     set_state('flannel.bridge.configured')
+
+
+@when_any('config.http_proxy.changed', 'config.https_proxy.changed')
+def rerender_service_template():
+    ''' If we change proxy settings, re-render the bootstrap service definition
+    and attempt to resume where we left off.  '''
+
+    # Note: At this point if we hijack the workload daemon, heavy fisted
+    # reprocussions will occur, like disruption  of services.
+
+    codename = host.lsb_release()['DISTRIB_CODENAME']
+    # by default, dont reboot the daemon unless we have previously rendered
+    # system files.
+
+    # Deterministic method to probe if we actually need to restart the
+    # daemon.
+    reboot = (os.path.exists('/lib/systemd/system/bootstrap-docker.service') or
+              os.path.exists('/etc/init/bootstrap-docker.conf'))
+
+    if codename != "trusty":
+        # Handle SystemD
+        render('bootstrap-docker.service',
+               '/lib/systemd/system/bootstrap-docker.service',
+               config(), owner='root', group='root')
+        cmd = ["systemctl", "daemon-reload"]
+        check_call(cmd)
+    else:
+        # Handle Upstart
+        render('bootstrap-docker.upstart',
+               '/etc/init/bootstrap-docker.conf',
+               config(), owner='root', group='root')
+
+    if reboot:
+        service_restart('bootstrap-docker')
 
 
 @when_any('config.cidr.changed', 'config.etcd_image.changed',

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -66,7 +66,7 @@ def deploy_docker_bootstrap_daemon():
         # Render the service definition
         render('bootstrap-docker.service',
                '/lib/systemd/system/bootstrap-docker.service',
-               {}, owner='root', group='root')
+               config(), owner='root', group='root')
         # let systemd allocate the unix socket
         render('bootstrap-docker.socket',
                '/lib/systemd/system/bootstrap-docker.socket',

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -173,6 +173,7 @@ def reconfigure_docker_for_sdn():
     check_call(split(cmd))
 
     set_state('docker.restart')
+    remove_state('flannel.configuring')
     set_state('flannel.bridge.configured')
 
 

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -20,6 +20,7 @@ from charmhelpers.core import unitdata
 
 import charms.apt
 import os
+import subprocess
 import time
 
 
@@ -121,11 +122,23 @@ def run_flannel(etcd):
         cert_path = '/etc/ssl/flannel'
     else:
         cert_path = None
-
+    # Put all the configuration values in the context dictionary.
     context.update(config())
+    iface = config('iface')
+    # When iface is None or empty string.
+    if not iface:
+        # Attempt to detect the default interface.
+        iface = get_default_interface()
+        # When detection not successful, print message and return.
+        if not iface:
+            status_set('blocked', "Interface detection failed. "
+                       "Set charm's iface config option.")
+            return
+    # Add additional key/values to the context dictionary.
     context.update({'charm_dir': os.getenv('CHARM_DIR'),
                     'connection_string': etcd.get_connection_string(),
                     'cert_path': cert_path})
+    # Render the flannel-compose.yml file using the current context.
     render('flannel-compose.yml', 'files/flannel/docker-compose.yml', context)
 
     compose = Compose('files/flannel',
@@ -133,7 +146,7 @@ def run_flannel(etcd):
     compose.up()
     # Give the flannel daemon a moment to actually generate the interface
     # configuration seed. Otherwise we enter a time/wait scenario which
-    # may cuase this to be called out of order and break the expectation
+    # may cause this to be called out of order and break the expectation
     # of the deployment.
     time.sleep(3)
     ingest_network_config()
@@ -164,7 +177,7 @@ def reconfigure_docker_for_sdn():
 
 
 @when_any('config.cidr.changed', 'config.etcd_image.changed',
-          'config.flannel_image.changed')
+          'config.flannel_image.changed', 'config.iface.changed')
 def reconfigure_flannel_network():
     ''' When the user changes the cidr, we need to reconfigure the
     backing etcd_store, and re-launch the flannel docker container.'''
@@ -208,3 +221,18 @@ def ingest_network_config():
 
     set_state('sdn.available')
     set_state('flannel.configuring')
+
+
+def get_default_interface():
+    '''Find the default network interface for this host.'''
+    cmd = ['route']
+    # The route command lists the default interfaces.
+    # Destination    Gateway        Genmask      Flags Metric Ref    Use Iface
+    # default        10.128.0.1     0.0.0.0      UG    0      0        0 ens4
+    output = subprocess.check_output(cmd).decode('utf8')
+    # Parse each onen of the lines.
+    for line in output.split('\n'):
+        # When the line contains 'default'.
+        if 'default' in line:
+            # The last column is the network interface.
+            return line.split(' ')[-1]

--- a/templates/bootstrap-docker.service
+++ b/templates/bootstrap-docker.service
@@ -26,5 +26,12 @@ Delegate=yes
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
 
+# Support proxy limited network envs
+{% if http_proxy or https_proxy  %}
+Environment="HTTP_PROXY={{ http_proxy }}"
+Environment="HTTPS_PROXY={{ https_proxy }}"
+{% endif %}
+
+
 [Install]
 WantedBy=multi-user.target

--- a/templates/bootstrap-docker.upstart
+++ b/templates/bootstrap-docker.upstart
@@ -9,6 +9,12 @@ respawn
 
 kill timeout 20
 
+# Support proxy limited environments
+{% if http_proxy or https_proxy %}
+env HTTP_PROXY={{ http_proxy }}
+env HTTPS_PROXY={{ https_proxy }}
+{% enif %}
+
 pre-start script
         # see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
         if grep -v '^#' /etc/fstab | grep -q cgroup \


### PR DESCRIPTION
- The workload docker daemon was getting consistently reset. This is
     problematic, as it interrupts the workloads running. An unintended
     side effect.

    The charm should now only re-render the template, and re-load the systctl
    definition, along with recycling the bootstrap-docker daemon. This has less
    impact on running workloads than interrupting the primary workload bridge.